### PR TITLE
Laravel [5.4] - Using the singleton method instead the Removed share method

### DIFF
--- a/src/FeedsServiceProvider.php
+++ b/src/FeedsServiceProvider.php
@@ -24,7 +24,7 @@ class FeedsServiceProvider extends ServiceProvider {
    * @return void
    */
   public function register() {
-    $this->app['Feeds'] = $this->app->share(function($app) {
+    $this->app->singleton('Feeds', function($app) {
       $config = config('feeds');
 
       if (!$config) {


### PR DESCRIPTION
The share method has been removed from the container. This was a legacy method that has not been documented in several years. so we should begin using the  singleton method instead