### PR TITLE
Allow self signed https RSS Feeds to be used

### DIFF
--- a/src/FeedsFactory.php
+++ b/src/FeedsFactory.php
@@ -57,7 +57,7 @@ class FeedsFactory
             $this->simplepie->set_cache_location($this->config['cache.location']);
             $this->simplepie->set_cache_duration($this->config['cache.life']);
         }
-        if ($this->config['ssl_check.disabled') {
+        if ($this->config['ssl_check.disabled']) {
             $this->simplepie->set_curl_options([
                 CURLOPT_SSL_VERIFYHOST => false,
                 CURLOPT_SSL_VERIFYPEER => false

--- a/src/FeedsFactory.php
+++ b/src/FeedsFactory.php
@@ -2,55 +2,66 @@
 
 use SimplePie;
 
-class FeedsFactory {
+class FeedsFactory
+{
 
-  protected $config;
+    protected $config;
 
-  protected $simplepie;
+    protected $simplepie;
 
-  /**
-   * @param $config
-   */
-  public function __construct($config) {
-    $this->config = $config;
-  }
-
-  /**
-   * @param array $feed_url RSS URL
-   * @param int $limit items returned per-feed with multifeeds
-   * @param bool|false $force_feed
-   *
-   * @return SimplePie
+    /**
+     * @param $config
      */
-    public function make($feed_url = [], $limit = 0, $force_feed = false) {
-    $this->simplepie = new SimplePie();
-    $this->configure();
-    $this->simplepie->set_feed_url($feed_url);
-    $this->simplepie->set_item_limit($limit);
-    if ( $force_feed === true ) $this->simplepie->force_feed(true);
-    if ( ! $this->config['strip_html_tags.disabled'] && ! empty( $this->config['strip_html_tags.tags'] ) && is_array($this->config['strip_html_tags.tags'])) {
-       $this->simplepie->strip_htmltags( $this->config['strip_html_tags.tags'] );
-     }else{
-       $this->simplepie->strip_htmltags( false );
+    public function __construct($config)
+    {
+        $this->config = $config;
     }
-    if ( ! $this->config['strip_attribute.disabled'] && ! empty( $this->config['strip_attribute.tags'] ) && is_array($this->config['strip_attribute.tags'])) {
-      $this->simplepie->strip_attributes( $this->config['strip_attribute.tags'] );
-    }else{
-      $this->simplepie->strip_attributes( false );
-    }
-    $this->simplepie->init();
-    $this->simplepie->handle_content_type();
 
-    return $this->simplepie;
-  }
+    /**
+     * @param array $feed_url RSS URL
+     * @param int $limit items returned per-feed with multifeeds
+     * @param bool|false $force_feed
+     *
+     * @return SimplePie
+     */
+    public function make($feed_url = [], $limit = 0, $force_feed = false)
+    {
+        $this->simplepie = new SimplePie();
+        $this->configure();
+        $this->simplepie->set_feed_url($feed_url);
+        $this->simplepie->set_item_limit($limit);
+        if ($force_feed === true) {
+            $this->simplepie->force_feed(true);
+        }
+        if (!$this->config['strip_html_tags.disabled'] && !empty($this->config['strip_html_tags.tags']) && is_array($this->config['strip_html_tags.tags'])) {
+            $this->simplepie->strip_htmltags($this->config['strip_html_tags.tags']);
+        } else {
+            $this->simplepie->strip_htmltags(false);
+        }
+        if (!$this->config['strip_attribute.disabled'] && !empty($this->config['strip_attribute.tags']) && is_array($this->config['strip_attribute.tags'])) {
+            $this->simplepie->strip_attributes($this->config['strip_attribute.tags']);
+        } else {
+            $this->simplepie->strip_attributes(false);
+        }
+        $this->simplepie->init();
+        $this->simplepie->handle_content_type();
 
-  protected function configure() {
-    if ($this->config['cache.disabled']) {
-      $this->simplepie->enable_cache(false);
+        return $this->simplepie;
     }
-    else {
-      $this->simplepie->set_cache_location($this->config['cache.location']);
-      $this->simplepie->set_cache_duration($this->config['cache.life']);
+
+    protected function configure()
+    {
+        if ($this->config['cache.disabled']) {
+            $this->simplepie->enable_cache(false);
+        } else {
+            $this->simplepie->set_cache_location($this->config['cache.location']);
+            $this->simplepie->set_cache_duration($this->config['cache.life']);
+        }
+        if ($this->config['ssl_check.disabled') {
+            $this->simplepie->set_curl_options([
+                CURLOPT_SSL_VERIFYHOST => false,
+                CURLOPT_SSL_VERIFYPEER => false
+            ]);
+        }
     }
-  }
 }

--- a/src/config/feeds.php
+++ b/src/config/feeds.php
@@ -32,7 +32,15 @@ return [
   |
   */
   'cache.disabled' => false,
-
+    /*
+  |--------------------------------------------------------------------------
+  | Disable Check for SSL certificates (enable for self signed certificates)
+  |--------------------------------------------------------------------------
+  |
+  |
+  |
+  */
+  'ssl_check.disabled' => false,
   /*
   |--------------------------------------------------------------------------
   | Strip Html Tags Disabled


### PR DESCRIPTION
Simple pie offers the option to use a RSS feed via HTTPS with self signed certificates.
I have added the option to allow the users of this wrapper to enable or disable this via config.