### PR TITLE
fix strip_attribute not working

### DIFF
--- a/src/config/feeds.php
+++ b/src/config/feeds.php
@@ -84,7 +84,7 @@ return [
     |
     |
     */
-    'strip_attributes.tags'    => [
+    'strip_attribute.tags'    => [
         'bgsound', 'class', 'expr', 'id', 'style', 'onclick', 'onerror', 'onfinish', 'onmouseover', 'onmouseout',
         'onfocus', 'onblur', 'lowsrc', 'dynsrc',
     ],


### PR DESCRIPTION
In the config file , strip_attribute has a 's' , but FeedFactory::make function just use strip_attribute