### PR TITLE
Add Custom User Agent from Config

### DIFF
--- a/src/FeedsFactory.php
+++ b/src/FeedsFactory.php
@@ -102,6 +102,10 @@ class FeedsFactory
             $this->simplePie->set_cache_duration($this->config['cache.life']);
         }
 
+	    if (isset($this->config['user_agent']) && !empty($this->config['user_agent'])) {
+		    $this->simplePie->set_useragent($this->config['user_agent']);
+	    }
+
         if (isset($this->config['curl.options']) && is_array($this->config['curl.options'])) {
             $curlOptions += $this->config['curl.options'];
         }

--- a/src/config/feeds.php
+++ b/src/config/feeds.php
@@ -102,4 +102,16 @@ return [
 
     'curl.timeout' => null,
 
+	/*
+	|--------------------------------------------------------------------------
+	| Custom User Agent
+	|--------------------------------------------------------------------------
+	|
+	| Some servers block or filter request using user agent rule, this config
+	| will help to pass it by providing custom user agent string.
+	| Set to null to use default
+	|
+	*/
+	'user_agent' => null,
+
 ];


### PR DESCRIPTION
## Problem

Some servers block request by filtering the user agent. We can pass this filter by providing custom user agent, so the request will not be rejected. By default, the user agent is:

```
SimplePie/1.5.6 (Feed Parser; http://simplepie.org; Allow like Gecko) Build/20201014071722
```

## Proposed Solution

This PR adds new feature to set custom user agent by utilizing Simplepie's `set_useragent()` function.

For keeping backward compatibility, it only sets if key `user_agent` is set and not empty or null.

### Example

This config will mimic a Firefox browser.

```php
// in src/config/feeds.php
'user_agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:85.0) Gecko/20100101 Firefox/85.0',
```

