### PR TITLE
Allow installation of SimplePie 1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=5.4.0 || ^7.2",
         "illuminate/support": "~5.0 || ^6.0 || ^7.0 || ^8.0|^9.0",
-        "simplepie/simplepie": "1.5.*",
+        "simplepie/simplepie": "^1.5",
         "ext-curl": "*"
     },
     "autoload": {


### PR DESCRIPTION
SimplePie 1.6.0 was released yesterday. Because SimplePie follows SemVer it is save to use the semver caret instead of the bugfix star.